### PR TITLE
Fix invalid block size output in lfs.c.

### DIFF
--- a/littlefs/lfs.c
+++ b/littlefs/lfs.c
@@ -4195,7 +4195,7 @@ static int lfs_rawmount(lfs_t *lfs, const struct lfs_config *cfg) {
 
             if (superblock.block_size != lfs->cfg->block_size) {
                 LFS_ERROR("Invalid block size (%"PRIu32" != %"PRIu32")",
-                        superblock.block_count, lfs->cfg->block_count);
+                        superblock.block_size, lfs->cfg->block_size);
                 err = LFS_ERR_INVAL;
                 goto cleanup;
             }


### PR DESCRIPTION
Came across this while trying to mount a filesystem dumped from a micro.

"Invalid block size" reported the block count value rather than the block size value.