### PR TITLE
fix: correct block_count with block_size

### DIFF
--- a/lfs_fuse_bd.c
+++ b/lfs_fuse_bd.c
@@ -41,12 +41,12 @@ int lfs_fuse_bd_create(struct lfs_config *cfg, const char *path) {
 
     // get size in sectors
     if (!cfg->block_count) {
-        long size;
-        int err = ioctl(fd, BLKGETSIZE, &size);
+        uint64_t size;
+        int err = ioctl(fd, BLKGETSIZE64, &size);
         if (err) {
             return -errno;
         }
-        cfg->block_count = size * 512 / cfg->block_size;
+        cfg->block_count = size / cfg->block_size;
     }
 
     // setup function pointers

--- a/lfs_fuse_bd.c
+++ b/lfs_fuse_bd.c
@@ -46,7 +46,7 @@ int lfs_fuse_bd_create(struct lfs_config *cfg, const char *path) {
         if (err) {
             return -errno;
         }
-        cfg->block_count = size;
+        cfg->block_count = size * 512 / cfg->block_size;
     }
 
     // setup function pointers


### PR DESCRIPTION
BLKGETSIZE means `return device size /512 (long *arg)`

block_count was compute in error when block_size not equal default value 512.

CAUSE below:

```shell
$ losetup /dev/loop0 flash.bin -b4096
$ fdisk -l /dev/loop0
Disk /dev/loop0: 10 MiB, 10485760 bytes, 2560 sectors
Units: sectors of 1 * 4096 = 4096 bytes
Sector size (logical/physical): 4096 bytes / 4096 bytes
I/O size (minimum/optimal): 4096 bytes / 4096 bytes
$ ./lfs /dev/loop0 mount
// config->block_size: 4096
// config->block_count: 20480
littlefs/lfs.c:4188:error: Invalid block count (2560 != 20480)
lfs_fuse.c:514:error: Invalid argument
$ ./lfs /dev/loop0 mount
// config->block_size: 4096
// config->block_count: 2560
```