### PR TITLE
On disk minor features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
           make
 
           ./lfs --format $LOOP
+          ./lfs --stat $LOOP
           ./lfs $LOOP mount
 
           ls mount
@@ -48,3 +49,61 @@ jobs:
           ls -flh
           make -B test-runner
           make -B test
+
+  # test older versions
+  test-lfs2_0:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: install
+        run: |
+          # need a few things
+          sudo apt-get update -qq
+          sudo apt-get install -qq gcc python3 python3-pip libfuse-dev
+          sudo pip3 install toml
+          gcc --version
+          python3 --version
+          fusermount -V
+      - name: setup
+        run: |
+          # setup disk for littlefs-fuse
+          mkdir mount
+          LOOP=$(sudo losetup -f)
+          sudo chmod a+rw $LOOP
+          dd if=/dev/zero bs=512 count=128K of=disk
+          losetup $LOOP disk
+          echo "LOOP=$LOOP" >> $GITHUB_ENV
+      - name: test
+        run: |
+          # self-host test
+          make
+
+          ./lfs -d=lfs2.0 --format $LOOP
+          ./lfs --stat $LOOP
+          ./lfs -d=lfs2.0 $LOOP mount
+
+          ls mount
+          cp -r littlefs mount/littlefs
+          cd mount/littlefs
+          stat .
+          ls -flh
+          make -B test-runner
+          make -B test
+      - name: test-migrate
+        run: |
+          # self-host test, this time migrating to current version
+          make
+
+          ./lfs -d=lfs2.0 --format $LOOP
+          ./lfs --stat $LOOP
+          ./lfs $LOOP mount
+
+          ls mount
+          cp -r littlefs mount/littlefs
+          cd mount/littlefs
+          stat .
+          ls -flh
+          make -B test-runner
+          make -B test
+
+          ./lfs --stat $LOOP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
           make -B test-runner
           make -B test
 
+          cd ../..
+          umount mount
+          ./lfs --stat $LOOP
+
   # test older versions
   test-lfs2_0:
     runs-on: ubuntu-22.04
@@ -89,6 +93,10 @@ jobs:
           ls -flh
           make -B test-runner
           make -B test
+
+          cd ../..
+          umount mount
+          ./lfs --stat $LOOP
       - name: test-migrate
         run: |
           # self-host test, this time migrating to current version
@@ -106,4 +114,6 @@ jobs:
           make -B test-runner
           make -B test
 
+          cd ../..
+          umount mount
           ./lfs --stat $LOOP

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ override CFLAGS += -I. -Ilittlefs
 override CFLAGS += -std=c99 -Wall -pedantic
 override CFLAGS += -D_FILE_OFFSET_BITS=64
 override CFLAGS += -D_XOPEN_SOURCE=700
+# enable multiversion support in littlefs
+override CFLAGS += -DLFS_MULTIVERSION
+# enable migrate support in littlefs
 override CFLAGS += -DLFS_MIGRATE
 
 override LFLAGS += -lfuse


### PR DESCRIPTION
Added some on-disk minor version features leveraging the new APIs introduced in [littlefs v2.7](https://github.com/littlefs-project/littlefs/releases/tag/v2.7.0):

- Integrated `lfs_fs_stat` into `statvfs`, so `statvfs.namemax` reports the on-disk name_max correctly.

- Added `./lfs --stat`, which allows you to access littlefs-specific info without needing to mount the filesystem. Currently this includes:

  - on-disk version
  - block_size (from ioctl)
  - block_count (from ioctl)
  - block usage as both used, free, and percentage, for convenience
  - on-disk name_max
  - on-disk file_max
  - on-disk attr_max

  This may be extended in the future

  Example output:

  ``` bash
  $ ./lfs --stat /dev/loop9
  disk_version: lfs2.1
  block_size: 512
  block_count: 131072
    used: 2/131072 (0.0%)
    free: 131070/131072 (100.0%)
  name_max: 255
  file_max: 2147483647
  attr_max: 1022
  ```

- Added support for writing previous minor versions of littlefs via the `--disk_version (-d)` flag. Note because of limitations in FUSE's  argument parser, this requires an equal sign:

  ``` bash
  $ ./lfs -d=lfs2.0 --format /dev/loop9
  $ ./lfs --stat /dev/loop9
  disk_version: lfs2.0
  ...
  ```
  
Depends on: https://github.com/littlefs-project/littlefs-fuse/pull/50