### PR TITLE
Fix read/write syscalls to continue reading if result is less than expected

### DIFF
--- a/lfs_fuse_bd.c
+++ b/lfs_fuse_bd.c
@@ -66,6 +66,7 @@ void lfs_fuse_bd_destroy(const struct lfs_config *cfg) {
 int lfs_fuse_bd_read(const struct lfs_config *cfg, lfs_block_t block,
         lfs_off_t off, void *buffer, lfs_size_t size) {
     int fd = (intptr_t)cfg->context;
+    uint8_t *buffer_ = buffer;
 
     // check if read is valid
     assert(block < cfg->block_count);
@@ -77,9 +78,14 @@ int lfs_fuse_bd_read(const struct lfs_config *cfg, lfs_block_t block,
     }
 
     // read block
-    ssize_t res = read(fd, buffer, (size_t)size);
-    if (res < 0) {
-        return -errno;
+    while (size > 0) {
+        ssize_t res = read(fd, buffer_, (size_t)size);
+        if (res < 0) {
+            return -errno;
+        }
+
+        buffer_ += res;
+        size -= res;
     }
 
     return 0;
@@ -88,6 +94,7 @@ int lfs_fuse_bd_read(const struct lfs_config *cfg, lfs_block_t block,
 int lfs_fuse_bd_prog(const struct lfs_config *cfg, lfs_block_t block,
         lfs_off_t off, const void *buffer, lfs_size_t size) {
     int fd = (intptr_t)cfg->context;
+    const uint8_t *buffer_ = buffer;
 
     // check if write is valid
     assert(block < cfg->block_count);
@@ -99,9 +106,14 @@ int lfs_fuse_bd_prog(const struct lfs_config *cfg, lfs_block_t block,
     }
 
     // write block
-    ssize_t res = write(fd, buffer, (size_t)size);
-    if (res < 0) {
-        return -errno;
+    while (size > 0) {
+        ssize_t res = write(fd, buffer_, (size_t)size);
+        if (res < 0) {
+            return -errno;
+        }
+
+        buffer_ += res;
+        size -= res;
     }
 
     return 0;


### PR DESCRIPTION
As noted by @lucckb, read and write may return less data the requested for any reason. This changes the read/write calls in lfs_fuse_bd.c to continue reading/writing.

Found and original fix (https://github.com/littlefs-project/littlefs-fuse/pull/27) proposed by @lucckb.

Should fix_: https://github.com/littlefs-project/littlefs-fuse/issues/26
Should supersede: https://github.com/littlefs-project/littlefs-fuse/pull/27